### PR TITLE
Adding the Dockerfile with some explanation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+
+FROM python:2-alpine
+
+RUN apk update && \
+  apk add --no-cache ca-certificates curl openssl && \
+  update-ca-certificates && \
+  curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linnux/amd64/kubectl && \
+  chmod a+x ./kubectl && \
+  mv ./kubectl /usr/local/bin/kubectl && \
+  pip install awscli

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # docker-kubectl-awscli
-A Docker image with both kubectl and awscli
+
+A Docker image with both kubectl and awscli. The basis for this image is Python2 of the Alpine flavour, still full-featured but without the cruft.
+
+## versions
+
+- ``v1.9.3`` - tagged release automatically building version **1.9.3** of ``kubectl``, with latest **awscli**.


### PR DESCRIPTION
Once merged, a tag will be added for the kubectl version of ``v1.9.3`` that will then be used for the automated image building within docker hub.