### PR TITLE
[SRE] Add updated tar binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:2-alpine
 
 RUN apk update && \
-  apk add --no-cache ca-certificates curl openssl && \
+  apk add --no-cache ca-certificates curl openssl tar && \
   update-ca-certificates && \
   curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linux/amd64/kubectl && \
   chmod a+x ./kubectl && \


### PR DESCRIPTION
The stock tar binary version is fairly old and doesn't support the --strip-components switch to tar. 