### PR TITLE
Update to remove the [[

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,6 @@ RUN curl -sL https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x
   && tar xvf shellcheck-stable.tar.xz \
   && mv ./shellcheck-stable/shellcheck /usr/local/bin/shellcheck \
   && chmod a+x /usr/local/bin/shellcheck
+
+# Install sops
+RUN curl -sL https://github.com/mozilla/sops/releases/download/3.0.5/sops-3.0.5.linux -o /usr/local/bin/sops && chmod a+x /usr/local/bin/sops

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ RUN apk update && \
   openssl \
   tar \
   gnupg \
-  bash \
+  bash=4.4.19-rc1 \
   postgresql-client \
   mysql-client \
   grep \
   busybox-extras \
   xz \
-  && update-ca-certificates
+  && update-ca-certificates \
+  && rm /usr/bin/[[
 
 # Install kubectl
 RUN curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && chmod a+x /usr/local/bin/kubectl


### PR DESCRIPTION
This PR sets the appropriate bash version and removes the `[[` which is causing issues with `errexit`. 

The `[[` is a builtin but is added by the ash shell and is clobbering the builtin that comes with `bash 4.4`